### PR TITLE
feat: use system provided libs for kissfft and libresample by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ endif ()
 
 option(BUILD_TEST "Build selftest executable" OFF)
 
+option(MUSLY_USE_OWN_LIBKISSFFT OFF)
+option(MUSLY_USE_OWN_LIBRESAMPLE OFF)
 
 #
 # Project Setup
@@ -83,8 +85,10 @@ check_ipo_supported(RESULT musly_IPO_SUPPORTED)
 # Dependencies
 #
 
-# make sure Eigen3 library is present
 include(FetchContent)
+
+# make sure Eigen3 library is present. Since it is header-only no need to insist on
+# using installed packages, but we'll take it when it is there.
 FetchContent_Declare(Eigen3
     URL      https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
     URL_HASH SHA256=8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
@@ -92,18 +96,24 @@ FetchContent_Declare(Eigen3
     EXCLUDE_FROM_ALL
     FIND_PACKAGE_ARGS NO_MODULE
 )
-
 FetchContent_MakeAvailable(Eigen3)
 
-# can be replaced with FetchContent_MakeAvailable(Eigen3), when CMake >= 3.28
-#FetchContent_GetProperties(Eigen3)
-#if(NOT eigen3_POPULATED)
-#  FetchContent_Populate(Eigen3)
-#  add_subdirectory(${eigen3_SOURCE_DIR} ${eigen3_BINARY_DIR} EXCLUDE_FROM_ALL)
-#endif()
+if(NOT MUSLY_USE_OWN_LIBRESAMPLE)
+    find_package(LibResample REQUIRED)
+else()
+    message(STATUS "Using vendored version of libresample.")
+    add_subdirectory(libresample)
+endif()
 
-add_subdirectory(libkissfft)
-add_subdirectory(libresample)
+if(NOT MUSLY_USE_OWN_LIBKISSFFT)
+    find_package(kissfft REQUIRED)
+else()
+    message(STATUS "Using vendored version of kissfft.")
+    add_subdirectory(libkissfft)
+endif()
+
+find_package(LibAV 4.3 COMPONENTS avcodec avformat avutil)
+
 add_subdirectory(libmusly)
 
 if (NOT IS_SUBPROJECT)
@@ -125,7 +135,7 @@ if (NOT IS_SUBPROJECT)
 endif()
 
 #
-# Export Configuration
+# Install CMake Config Package
 #
 
 configure_package_config_file(
@@ -156,6 +166,20 @@ export(PACKAGE Musly)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/MuslyConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/MuslyConfigVersion.cmake
     DESTINATION ${musly_CMAKEPKG_INSTALL_DIR}
+)
+
+#
+# Install pkg-config configuration file
+#
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libmusly.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libmusly.pc
+    @ONLY
+)
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/libmusly.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 #

--- a/cmake/FindLibResample.cmake
+++ b/cmake/FindLibResample.cmake
@@ -1,0 +1,64 @@
+#[=======================================================================[.rst:
+FindLibResample
+---------------
+
+Locate libresample.
+
+This module defines:
+
+``LIBRESAMPLE_FOUND``
+  if false, do not try to link with libresample
+``LIBRESAMPLE_LIBRARY``
+  location of libresample library
+``LIBRESAMLE_INCLUDE_DIR``
+  location of libresample.h
+``resample::resample``
+  target for libresample for usage in target_link_libraries()
+
+#]=======================================================================]
+include(FindPackageHandleStandardArgs)
+
+find_path(LIBRESAMPLE_INCLUDE_DIR
+    NAMES libresample.h
+    HINTS
+        ENV LIBRESAMPLE_DIR
+    PATH_SUFFIXES include
+)
+
+find_library(LIBRESAMPLE_LIBRARY
+    NAMES resample
+    HINTS
+        ENV LIBRESAMPLE_DIR
+    PATH_SUFFIXES lib
+)
+
+set(_libresample_library_type SHARED)
+if(LIBRESAMPLE_LIBRARY)
+    if(UNIX)
+        get_filename_component(_libresample_ext ${LIBRESAMPLE_LIBRARY} EXT)
+        if(_libresample_ext STREQUAL ${CMAKE_STATIC_LIBRARY_SUFFIX})
+            set(_libresample_library_type STATIC)
+        endif()
+        unset(_libresample_ext)
+    endif()
+endif()
+
+find_package_handle_standard_args(
+    LibResample
+    REQUIRED_VARS 
+        LIBRESAMPLE_INCLUDE_DIR 
+        LIBRESAMPLE_LIBRARY
+)
+
+if(LIBRESAMPLE_FOUND)
+    message(STATUS "-I ${LIBRESAMPLE_INCLUDE_DIR}, -L ${LIBRESAMPLE_LIBRARY}")
+    add_library(resample::resample ${_libresample_library_type} IMPORTED)
+
+    set_target_properties(resample::resample PROPERTIES
+        IMPORTED_LOCATION "${LIBRESAMPLE_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LIBRESAMPLE_INCLUDE_DIR}"
+    )
+endif()
+
+unset(_libresample_library_type)
+

--- a/cmake/libmusly.pc.in
+++ b/cmake/libmusly.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+include_dir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: libmusly
+Description: A library for music similarity computation
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lmusly
+Cflags: -I${include_dir}

--- a/libkissfft/CMakeLists.txt
+++ b/libkissfft/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(libkissfft STATIC
     src/kiss_fft.c
     src/kiss_fftr.c
 )
+add_library(kissfft::kissfft-float ALIAS libkissfft)
 
 target_include_directories(libkissfft 
     PRIVATE 

--- a/libmusly/CMakeLists.txt
+++ b/libmusly/CMakeLists.txt
@@ -99,13 +99,12 @@ target_sources(libmusly
 # add common link libraries
 target_link_libraries(libmusly
     PRIVATE
-        libkissfft
-        libresample
+        kissfft::kissfft-float
+        resample::resample
         Eigen3::Eigen
 )
 
 # enable libav decoder support when available
-find_package(LibAV 0.8 COMPONENTS avcodec avformat avutil)
 if(LIBAV_FOUND)
     target_sources(libmusly
         PRIVATE src/decoders/libav.cpp

--- a/libmusly/src/resampler.h
+++ b/libmusly/src/resampler.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 extern "C" {
-    #include "libresample.h"
+    #include <libresample.h>
 }
 
 namespace musly {

--- a/libresample/CMakeLists.txt
+++ b/libresample/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(libresample STATIC
     src/resamplesubs.c
     src/resample.c
 )
+add_library(resample::resample ALIAS libresample)
 
 target_include_directories(libresample 
     PRIVATE 


### PR DESCRIPTION
- to use vendored dependencies you can enable them by setting MUSLY_USE_OWN_{LIBRESAMPLE,LIBKISSFFT} to TRUE
- added pkg-config .pc file for libmusly